### PR TITLE
Changed method to filter out unwanted php processes from debug import

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -1,12 +1,16 @@
 <?php
 define('DAHL_DEVROOT', dirname(__file__));
-if (
-    strpos($_SERVER['SCRIPT_NAME'], 'composer') !== false
-    || strpos($_SERVER['SCRIPT_NAME'], 'magerun') !== false
-    || strpos($_SERVER['SCRIPT_NAME'], 'cron.php') !== false
-) {
+
+/**
+ * Will on only execute if it is a PHP process and not a phar file or
+ * other type of binary file.
+ */
+if (PHP_SAPI === 'cli'
+    && isset($_SERVER['_'])
+    && PHP_BINDIR . DIRECTORY_SEPARATOR . 'php' !== $_SERVER['_']) {
     return;
 }
+
 function buildPath() {
     $args = func_get_args();
     return implode(DIRECTORY_SEPARATOR, $args);


### PR DESCRIPTION
Changed the way to determine if a process is unsupported by the debug module.

Will not execute for
- Composer
- Magerun
- PHP Code Sniffer

Will still execute for random php code. 
