### PR TITLE
Changed so that modules can be disabled in project config.

### DIFF
--- a/magento.php
+++ b/magento.php
@@ -63,6 +63,7 @@ class dahl_dev
         }
         $this->_readConfigFiles();
         $this->_initSetup();
+        $this->_config->loadExternalModules();
     }
 
     /**

--- a/magento/config.php
+++ b/magento/config.php
@@ -43,6 +43,90 @@ class dahl_dev_config
     protected $_staticUrls = array();
 
     /**
+     * Registered external modules to be loaded
+     * 
+     * @var array
+     * @access protected
+     */
+    protected $_registeredModules = array();
+
+    /**
+     * Register external module to be loaded
+     * 
+     * @param string $path  The path to the root where files are located.
+     * @param stirng $url   An url from where static files can be loaded.
+     * @access public
+     * @return void
+     */
+    public function enableExternal($path, $skinUrl = null)
+    {
+        if (is_array($path)) {
+            foreach ($path as $p) {
+                return $this->enableExternal($p, $skinUrl);
+            }
+        }
+
+        $this->_registeredModules[$path] = $skinUrl;
+    }
+
+    /**
+     * Unregister external module to be loaded
+     * 
+     * @param string $path  The path to the root where files are located.
+     * @access public
+     * @return void
+     */
+    public function disableExternal($path)
+    {
+        if (is_array($path)) {
+            foreach ($path as $p) {
+                return $this->disableExternal($p, $skinUrl);
+            }
+        }
+        unset($this->_registeredModules[$path]);
+    }
+
+    /**
+     * Load all registered external modules
+     * 
+     * @access public
+     * @return void
+     */
+    public function loadExternalModules()
+    {
+        $this->_processModuleCookies();
+
+        foreach ($this->_registeredModules as $path => $skinUrl) {
+            $this->loadExternal($path, $skinUrl);
+        }
+    }
+
+    /**
+     * Process module cookie to enable/disable external modules
+     * 
+     * @access protected
+     * @return void
+     */
+    protected function _processModuleCookies()
+    {
+        if (isset($_COOKIE['enableModule'])) {
+            $enable = $_COOKIE['enableModule'];
+            $modules = explode(",", $enable);
+            foreach ($modules as $module) {
+                $this->enableExternal($module);
+            }
+        }
+
+        if (isset($_COOKIE['disableModule'])) {
+            $disable = $_COOKIE['disableModule'];
+            $modules = explode(",", $disable);
+            foreach ($modules as $module) {
+                $this->disableExternal($module);
+            }
+        }
+    }
+
+    /**
      * Load external resources.
      * 
      * @param string $path  The path to the root where files are located.
@@ -57,6 +141,7 @@ class dahl_dev_config
                 return $this->loadExternal($p, $skinUrl);
             }
         }
+
         $realpath = realpath($this->getModulePath() . DS . $path);
         if (!is_dir($realpath)) {
             $realpath = $path;

--- a/magento/config.php
+++ b/magento/config.php
@@ -53,7 +53,7 @@ class dahl_dev_config
     /**
      * Register external module to be loaded
      * 
-     * @param string $path  The path to the root where files are located.
+     * @param string|array $path  The path to the root where files are located.
      * @param stirng $url   An url from where static files can be loaded.
      * @access public
      * @return void
@@ -66,13 +66,15 @@ class dahl_dev_config
             }
         }
 
-        $this->_registeredModules[$path] = $skinUrl;
+        if (is_string($path)) {
+            $this->_registeredModules[$path] = $skinUrl;
+        }
     }
 
     /**
      * Unregister external module to be loaded
      * 
-     * @param string $path  The path to the root where files are located.
+     * @param string|array $path  The path to the root where files are located.
      * @access public
      * @return void
      */
@@ -83,7 +85,10 @@ class dahl_dev_config
                 $this->disableExternal($p);
             }
         }
-        unset($this->_registeredModules[$path]);
+
+        if (is_string($path)) {
+            unset($this->_registeredModules[$path]);
+        }
     }
 
     /**

--- a/magento/config.php
+++ b/magento/config.php
@@ -62,7 +62,7 @@ class dahl_dev_config
     {
         if (is_array($path)) {
             foreach ($path as $p) {
-                return $this->enableExternal($p, $skinUrl);
+                $this->enableExternal($p, $skinUrl);
             }
         }
 
@@ -80,7 +80,7 @@ class dahl_dev_config
     {
         if (is_array($path)) {
             foreach ($path as $p) {
-                return $this->disableExternal($p, $skinUrl);
+                $this->disableExternal($p);
             }
         }
         unset($this->_registeredModules[$path]);


### PR DESCRIPTION
Changed so that instead of loading the external modules directly via calling the loadExternal function, you register the module with enableExternal. Then all the modules are loaded like before after local.php is included.
This enables you to disable a module in your project config that is enabled in the global configuration local.php.

I also added the ability to set enabled or disabled modules via cookies in the browser so you can easily toggle a module on and off.
